### PR TITLE
Fixed index out of bounds error when writing column names to csv

### DIFF
--- a/back_end/flaskr/query_to_json/sqlite_to_json.py
+++ b/back_end/flaskr/query_to_json/sqlite_to_json.py
@@ -15,7 +15,7 @@ def sqlite_to_json(query_output):
 
 
 def write_to_csv(query_output):
-    with open('query_output.csv', 'w', newline='') as csvfile:
+    with open('../front_end/public/query_output.csv', 'w', newline='') as csvfile:
         writer = csv.writer(csvfile, dialect='excel') 
         # writer.writerow(query_output[0]) # column names
 

--- a/front_end/.gitignore
+++ b/front_end/.gitignore
@@ -21,3 +21,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+# local instance
+query_output.csv


### PR DESCRIPTION
Queries with no output now write **nothing** to CSV, and return an empty list.